### PR TITLE
Reduce the polling duration

### DIFF
--- a/cluster.js
+++ b/cluster.js
@@ -43,6 +43,8 @@ if (cluster.isMaster) {
     redisSub: sub,
     redisClient: cmd
   }));
+  
+  io.set('polling duration', 3);
 
   io.sockets.on('connection', function (socket) {});
 


### PR DESCRIPTION
Might be good to test by forcing socket.io to kill polls after a 3 second wait for testing.
